### PR TITLE
Add some optimizations with Dagger with the cache and remove the gcloud config in Dagger.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o bin/bigtestyapp
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o bin/bigtestyapp
 
 FROM alpine:latest
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ BigTesty is a framework that allows to create Integration Tests with BigQuery on
     -v $HOME/.config/gcloud:/root/.config/gcloud \
     bigtesty
 ```
+
+```
+docker build -f Dockerfile -t bigtesty  --progress plain .
+```

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func generateRandomString(length int) string {
 
 func main() {
 	ctx := context.Background()
-	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 
 	bigTestyEnvImageName := "ttl.sh/bigtesty-env:8h"
 
@@ -49,7 +49,6 @@ func main() {
 	testRootFolderKey := "TEST_ROOT_FOLDER"
 	datasetsHashKey := "DATASETS_HASH"
 
-	gcloudContainerConfigPath := "/root/.config/gcloud"
 	testFolderPath := "/app/tests"
 	tablesFolderPath := "/app/bigtesty/infra/resource/tables"
 
@@ -69,9 +68,9 @@ func main() {
 
 	hostSourceDir := client.Host().Directory(".", dagger.HostDirectoryOpts{})
 
-	gcloudConfigSourceDir := client.Host().Directory(
-		os.Getenv("HOME")+"/.config/gcloud", dagger.HostDirectoryOpts{},
-	)
+	//gcloudConfigSourceDir := client.Host().Directory(
+	//	os.Getenv("HOME")+"/.config/gcloud", dagger.HostDirectoryOpts{},
+	//)
 
 	testsSourceDir := client.Host().Directory(
 		testFolderPath, dagger.HostDirectoryOpts{},
@@ -90,7 +89,7 @@ func main() {
 	installInfra := client.Container().
 		From(bigTestyEnvImageName).
 		WithWorkdir("/app").
-		WithMountedDirectory(gcloudContainerConfigPath, gcloudConfigSourceDir).
+		//WithMountedDirectory(gcloudContainerConfigPath, gcloudConfigSourceDir).
 		WithMountedDirectory(tablesFolderPath, tablesSourceDir).
 		WithDirectory(".", source).
 		WithEnvVariable(pulumiProjectIdKey, projectId).
@@ -111,7 +110,7 @@ func main() {
 
 	insertionTestData := client.Container().
 		From(bigTestyEnvImageName).
-		WithMountedDirectory(gcloudContainerConfigPath, gcloudConfigSourceDir).
+		//WithMountedDirectory(gcloudContainerConfigPath, gcloudConfigSourceDir).
 		WithMountedDirectory(testFolderPath, testsSourceDir).
 		WithDirectory(".", installInfra).
 		WithEnvVariable(projectIdKey, projectId).
@@ -130,7 +129,7 @@ func main() {
 	executeQueriesDestroyInfraAndAssertions := client.Container().
 		From(bigTestyEnvImageName).
 		WithWorkdir("/app").
-		WithMountedDirectory(gcloudContainerConfigPath, gcloudConfigSourceDir).
+		//WithMountedDirectory(gcloudContainerConfigPath, gcloudConfigSourceDir).
 		WithMountedDirectory(tablesFolderPath, tablesSourceDir).
 		WithDirectory(".", insertionTestData).
 		WithEnvVariable(pulumiProjectIdKey, projectId).
@@ -152,7 +151,7 @@ func main() {
 	out, err := executeQueriesDestroyInfraAndAssertions.Stdout(ctx)
 
 	if err != nil {
-		panic(err)
+		fmt.Printf("Error %v", err)
 	}
 
 	fmt.Printf("Published image to: %s\n", out)


### PR DESCRIPTION
Add some optimizations with Dagger with the cache. Remove the gcloud config as volume in the Dagger code, because it's not needed from Cloud Bluid and a runner from a GCP service. It's ueful for an execution from our local machine and we need to deal with local executions.