### PR TITLE
Feature/deploy package pypi ci cd

### DIFF
--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -1,0 +1,36 @@
+name: Publish Package PyPi Test
+
+on:
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: 3.9.18
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install packages
+        run: |
+          pip install wheel
+          pip install twine
+
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish library to PyPi
+        run: |
+          python -m twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+        env:
+          TWINE_USERNAME: ${{ vars.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,36 @@
+name: Publish Package PyPi
+
+on:
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: 3.9.18
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install packages
+        run: |
+          pip install wheel
+          pip install twine
+
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish library to PyPi
+        run: |
+          python -m twine upload --verbose dist/*
+        env:
+          TWINE_USERNAME: ${{ vars.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PULUMI_VERSION=3.109.0
+ARG PULUMI_VERSION=3.111.1
 
 FROM pulumi/pulumi-python:${PULUMI_VERSION} AS bigtesty
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+import pathlib
+
 from setuptools import find_packages, setup
+
+HOME_DIR = pathlib.Path(__file__).parent
+
+# The text of the README file
+README = (HOME_DIR / "README.md").read_text()
 
 setup(
     name="bigtesty",
@@ -15,5 +22,17 @@ setup(
         "deepdiff==6.3.0",
         "toolz==0.12.0"
     ],
+    description="BigTesty is an integration testing framework for BigQuery",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    url="https://github.com/tosun-si/bigtesty",
+    author="Mazlum TOSUN",
+    author_email="mazlum.tosun@gmail.com",
     packages=find_packages(),
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent"
+    ],
+    python_requires='>=3.9.18',
 )


### PR DESCRIPTION
- Add the CI CI pipeline to publish the BigTesty package to PyPi
- Set the Python version yo 3.9.18 because the Pulumi Python package uses this version 
- Add CI CD pipeline to publish the package Test PyPi for testing purpose
- In the setup.py file, add the README as package description from PyPi and set the license + author. 