### PR TITLE
Remove the scenario IDs from testing configuration files and use a scenario hash instead

### DIFF
--- a/bigtesty/dataset_helper.py
+++ b/bigtesty/dataset_helper.py
@@ -1,5 +1,4 @@
 def build_unique_dataset_id_for_scenario(dataset_id: str,
-                                         scenario_id: str,
-                                         datasets_hash: str,
-                                         ) -> str:
-    return f'{dataset_id}_{scenario_id}_{datasets_hash}'
+                                         scenario_hash: str,
+                                         datasets_hash: str) -> str:
+    return f'{dataset_id}_{scenario_hash}_{datasets_hash}'

--- a/bigtesty/definition_test_config_helper.py
+++ b/bigtesty/definition_test_config_helper.py
@@ -2,6 +2,8 @@ import glob
 import json
 from typing import List, Dict
 
+from deepdiff import DeepHash
+
 from bigtesty.definition_test_file_exception import DefinitionTestFileException
 from bigtesty.lambda_functions import flat_map
 
@@ -49,3 +51,7 @@ def get_definition_tests_file_paths(data_testing_root_path: str) -> List[str]:
 def to_definition_test_dict(definition_test_file_path: str):
     with open(definition_test_file_path) as definition_test_file:
         return json.load(definition_test_file)
+
+
+def get_scenario_hash(scenario_dict: Dict) -> str:
+    return DeepHash(scenario_dict)[scenario_dict]

--- a/bigtesty/given/insertion_test_data_bigquery.py
+++ b/bigtesty/given/insertion_test_data_bigquery.py
@@ -3,6 +3,7 @@ from typing import List, Dict
 from google.cloud import bigquery
 
 from bigtesty.dataset_helper import build_unique_dataset_id_for_scenario
+from bigtesty.definition_test_config_helper import get_scenario_hash
 from bigtesty.files_loader_helper import load_file_as_dicts
 
 
@@ -27,7 +28,7 @@ def insert_test_data_to_bq_tables(
 
             dataset_id_with_hash = build_unique_dataset_id_for_scenario(
                 dataset_id=given['destination_dataset'],
-                scenario_id=scenario["id"],
+                scenario_hash=get_scenario_hash(scenario),
                 datasets_hash=datasets_hash
             )
 

--- a/bigtesty/infra/create_iac_for_datasets_with_tables.py
+++ b/bigtesty/infra/create_iac_for_datasets_with_tables.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from pulumi_gcp.bigquery import Dataset
 
 from bigtesty.dataset_helper import build_unique_dataset_id_for_scenario
+from bigtesty.definition_test_config_helper import get_scenario_hash
 from bigtesty.infra.datasets_with_tables_factory import get_dataset, get_table_with_partitioning, get_table
 
 
@@ -14,7 +15,7 @@ def create_datasets_and_tables(root_tables_folder: str,
         for scenario in scenarios:
             dataset_id_with_hash = build_unique_dataset_id_for_scenario(
                 dataset_id=dataset_config["datasetId"],
-                scenario_id=scenario["id"],
+                scenario_hash=get_scenario_hash(scenario),
                 datasets_hash=datasets_hash
             )
 

--- a/bigtesty/then/assertion_and_tests_reports_result.py
+++ b/bigtesty/then/assertion_and_tests_reports_result.py
@@ -7,6 +7,7 @@ from google.cloud.bigquery import Client
 from toolz.curried import pipe, map
 
 from bigtesty.dataset_helper import build_unique_dataset_id_for_scenario
+from bigtesty.definition_test_config_helper import get_scenario_hash
 from bigtesty.files_loader_helper import load_file_as_string, load_file_as_dicts
 from bigtesty.then.failure_test_exception import FailureTestException
 
@@ -51,7 +52,7 @@ def _execute_query_and_build_report_result(bigquery_python_client: Client,
         print(then)
 
         query = _build_query(
-            scenario_id=scenario["id"],
+            scenario=scenario,
             datasets_hash=datasets_hash,
             root_test_folder=root_test_folder,
             given_list=given_list,
@@ -91,7 +92,7 @@ def _execute_query_and_build_report_result(bigquery_python_client: Client,
         }
 
 
-def _build_query(scenario_id: str,
+def _build_query(scenario: Dict,
                  datasets_hash: str,
                  root_test_folder: str,
                  given_list: List[Dict],
@@ -104,7 +105,7 @@ def _build_query(scenario_id: str,
         sql_query_result = _replace_current_dataset_by_unique_dataset_for_scenario(
             sql_query=sql_query,
             current_dataset=given["destination_dataset"],
-            scenario_id=scenario_id,
+            scenario_hash=get_scenario_hash(scenario),
             datasets_hash=datasets_hash
         )
 
@@ -113,11 +114,11 @@ def _build_query(scenario_id: str,
 
 def _replace_current_dataset_by_unique_dataset_for_scenario(sql_query: str,
                                                             current_dataset: str,
-                                                            scenario_id: str,
+                                                            scenario_hash: str,
                                                             datasets_hash: str) -> str:
     unique_dataset_with_for_scenario = build_unique_dataset_id_for_scenario(
         dataset_id=current_dataset,
-        scenario_id=scenario_id,
+        scenario_hash=scenario_hash,
         datasets_hash=datasets_hash
     )
 

--- a/examples/tests/monitoring/definition_spec_failure_by_feature_name_no_error.json
+++ b/examples/tests/monitoring/definition_spec_failure_by_feature_name_no_error.json
@@ -2,7 +2,6 @@
   "description": "Test of monitoring data",
   "scenarios": [
     {
-      "id": "1239",
       "description": "Nominal case find failure by feature name",
       "given": [
         {

--- a/examples/tests/monitoring/definition_spec_failure_by_job_name_no_error.json
+++ b/examples/tests/monitoring/definition_spec_failure_by_job_name_no_error.json
@@ -2,7 +2,6 @@
   "description": "Test of monitoring data",
   "scenarios": [
     {
-      "id": "1240",
       "description": "Nominal case find failure by job name",
       "given": [
         {


### PR DESCRIPTION
Remove the scenario IDs from testing configuration files and use a scenario hash instead scenario hash instead. The scenario hash is based in a scenario Dict retrieved from the Json configuration file.