### PR TITLE
Correction in the CI example that concerns Cloud Build. 

### DIFF
--- a/examples/ci/cloud_build/run-tests-cloud-build.yaml
+++ b/examples/ci/cloud_build/run-tests-cloud-build.yaml
@@ -9,6 +9,6 @@ steps:
         --root-tables-folder /workspace/examples/tests/tables \
         --tables-config-file /workspace/examples/tests/tables/tables.json
     env:
-      - 'GOOGLE_PROJECT=$PROJECT_ID'
-      - 'GOOGLE_REGION=$LOCATION'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - 'LOCATION=$LOCATION'
       - 'IAC_BACKEND_URL=$_IAC_BACKEND_URL'


### PR DESCRIPTION
Correction in the CI example that concerns Cloud Build. Some env vars weren't corrects like the GCP project ID and region.