### PR TITLE
Isolate the state with an unique name datasethash-bigtesty. With this…

### DIFF
--- a/bigtesty/arguments.py
+++ b/bigtesty/arguments.py
@@ -1,7 +1,0 @@
-import argparse
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--root_folder', dest='root_folder', type=str, help='Root folder')
-parser.add_argument('--project_id', dest='project_id', type=str, help='GCP Project ID')
-parser.add_argument('--datasets_hash', dest='datasets_hash', type=str, help='Unique hash to isolate datasets')
-args = parser.parse_args()

--- a/bigtesty/cli/main.py
+++ b/bigtesty/cli/main.py
@@ -6,6 +6,7 @@ from typing_extensions import Annotated
 from bigtesty.cli.cli_env_vars import ROOT_TEST_FOLDER_KEY, ROOT_TABLES_FOLDER_KEY, TABLES_CONFIG_FILE_KEY, \
     KEEP_INFRA_KEY, BIGTESTY_STACK_NAME_KEY, PULUMI_CONFIG_PASSPHRASE_KEY, PULUMI_BACKEND_URL_KEY, IAC_BACKEND_URL_KEY, \
     BIGTESTY_STACK_NAME_VALUE, PULUMI_CONFIG_PASSPHRASE_VALUE, GOOGLE_PROJECT_KEY, GOOGLE_REGION_KEY
+from bigtesty.infra.infra_input_params import InfraInputParams
 from bigtesty.infra.launch_tests_ephemeral_infra import launch_tests_ephemeral_infra
 
 app = typer.Typer()
@@ -85,12 +86,18 @@ def run_tests(
     os.environ[PULUMI_CONFIG_PASSPHRASE_KEY] = PULUMI_CONFIG_PASSPHRASE_VALUE
     os.environ[BIGTESTY_STACK_NAME_KEY] = BIGTESTY_STACK_NAME_VALUE
 
-    launch_tests_ephemeral_infra(
+    infra_input_params = InfraInputParams(
+        project_id=project,
+        region=region,
+        stack_name=BIGTESTY_STACK_NAME_VALUE,
         root_test_folder=root_test_folder,
         root_tables_folder=root_tables_folder,
         tables_config_file_path=tables_config_file_path,
+        iac_backend_url=iac_backend_url,
         keep_infra=keep_infra
     )
+
+    launch_tests_ephemeral_infra(infra_input_params)
 
 
 @app.command("help")

--- a/bigtesty/infra/infra_input_params.py
+++ b/bigtesty/infra/infra_input_params.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class InfraInputParams:
+    project_id: str
+    region: str
+    stack_name: str
+    root_test_folder: str
+    root_tables_folder: str
+    tables_config_file_path: str
+    iac_backend_url: str
+    keep_infra: bool

--- a/bigtesty/infra/launch_tests_ephemeral_infra.py
+++ b/bigtesty/infra/launch_tests_ephemeral_infra.py
@@ -1,34 +1,42 @@
 import json
-import os
+import re
 import sys
 import traceback
 from typing import List, Dict
 
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+from google.cloud.storage import Bucket
 from pulumi import automation as auto
+from pulumi.automation import Stack
 
 from bigtesty.definition_test_config_helper import get_scenarios
 from bigtesty.given.insertion_test_data_bigquery import insert_test_data_to_bq_tables
 from bigtesty.infra.create_iac_for_datasets_with_tables import create_datasets_and_tables
 from bigtesty.infra.datasets_with_tables_config_file_loader import get_datasets_hash, \
     _load_file_as_dicts
+from bigtesty.infra.infra_input_params import InfraInputParams
 from bigtesty.then.assertion_and_tests_reports_result import execute_query_and_build_reports_result, \
     check_any_failed_test_in_reports
 
 
-def launch_tests_ephemeral_infra(root_test_folder: str,
-                                 root_tables_folder: str,
-                                 tables_config_file_path: str,
-                                 keep_infra: bool):
+def launch_tests_ephemeral_infra(infra_input_params: InfraInputParams):
     datasets_hash = get_datasets_hash(5)
 
-    project_id = os.environ["GOOGLE_PROJECT"]
-    region = os.environ["GOOGLE_REGION"]
-    stack_name = f'{datasets_hash}-{os.environ["BIGTESTY_STACK_NAME"]}'
+    project_id = infra_input_params.project_id
+    region = infra_input_params.region
+    unique_stack_name = f'{infra_input_params.stack_name}-{datasets_hash}'
+
+    root_test_folder = infra_input_params.root_test_folder
+    root_tables_folder = infra_input_params.root_tables_folder
+    tables_config_file_path = infra_input_params.tables_config_file_path
+    iac_backend_url = infra_input_params.iac_backend_url
+    keep_infra = infra_input_params.keep_infra
 
     scenarios = get_scenarios(root_test_folder)
 
     stack = auto.create_or_select_stack(
-        stack_name=stack_name,
+        stack_name=unique_stack_name,
         project_name=project_id,
         program=lambda: pulumi_program(scenarios,
                                        datasets_hash,
@@ -92,12 +100,11 @@ def launch_tests_ephemeral_infra(root_test_folder: str,
         exception_traceback = ''.join(traceback.format_tb(e.__traceback__))
         print(exception_traceback, file=sys.stderr)
 
-        stack.destroy(
-            on_output=print,
-            color="always",
-            show_secrets=False,
-            log_flow=True,
-            log_verbosity=3
+        destroy_infra_and_delete_empty_state_files(
+            stack=stack,
+            project_id=project_id,
+            backend_url=iac_backend_url,
+            stack_name=unique_stack_name
         )
 
         sys.exit(-1)
@@ -106,13 +113,14 @@ def launch_tests_ephemeral_infra(root_test_folder: str,
 
     if not keep_infra:
         print("################### Destroying the ephemeral infra and tests assertions...")
-        stack.destroy(
-            on_output=print,
-            color="always",
-            show_secrets=False,
-            log_flow=True,
-            log_verbosity=3
+
+        destroy_infra_and_delete_empty_state_files(
+            stack=stack,
+            project_id=project_id,
+            backend_url=iac_backend_url,
+            stack_name=unique_stack_name
         )
+
         print("############### Destroy ephemeral infra complete")
 
     print("############### Checking if there is any failed test...")
@@ -132,3 +140,65 @@ def pulumi_program(scenarios: List[Dict],
         datasets_hash=datasets_hash,
         scenarios=scenarios
     )
+
+
+def destroy_infra_and_delete_empty_state_files(
+        stack: Stack,
+        project_id: str,
+        backend_url: str,
+        stack_name: str):
+    """
+     Destroy the ephemeral infra and after destroying it, remove the empty state files.
+     The Pulumi CLI proposes the --remove option to remove the stack and the config files,
+     but this feature is not yet available in the Automation API.
+
+     We apply this logic in our side temporary and when this feature will be available
+     in the Automation API, we will use it.
+
+     There are empty files to remove:
+     - {stack_name}.json
+     - {stack_name}.json.back
+    """
+
+    stack.destroy(
+        on_output=print,
+        color="always",
+        show_secrets=False,
+        log_flow=True,
+        log_verbosity=3
+    )
+
+    empty_state_file = f"{stack_name}.json"
+    empty_state_file_bak = f"{empty_state_file}.bak"
+
+    pattern = r"gs://([^/]+)/(.+)"
+    match = re.search(pattern, backend_url)
+
+    bucket_name = match.group(1)
+    prefix = match.group(2)
+
+    stack_object_path = f"{prefix}/.pulumi/stacks/{project_id}"
+    object_state_file_name = f"{stack_object_path}/{empty_state_file}"
+    object_state_bak_file_name = f"{stack_object_path}/{empty_state_file_bak}"
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+
+    delete_empty_state_file(bucket, object_state_file_name)
+    delete_empty_state_file(bucket, object_state_bak_file_name)
+
+
+def delete_empty_state_file(bucket: Bucket, state_object_name: str):
+    try:
+        print(f"############# After destroyed the ephemeral infra, removing the empty state file: {state_object_name}")
+
+        blob = bucket.blob(state_object_name)
+
+        blob.reload()
+        generation_match_precondition = blob.generation
+
+        blob.delete(if_generation_match=generation_match_precondition)
+
+        print(f"############# The empty State file {state_object_name} was deleted.")
+    except NotFound:
+        print(f"############# Error when trying to delete the empty State file: {state_object_name}")

--- a/bigtesty/infra/launch_tests_ephemeral_infra.py
+++ b/bigtesty/infra/launch_tests_ephemeral_infra.py
@@ -19,11 +19,11 @@ def launch_tests_ephemeral_infra(root_test_folder: str,
                                  root_tables_folder: str,
                                  tables_config_file_path: str,
                                  keep_infra: bool):
+    datasets_hash = get_datasets_hash(5)
+
     project_id = os.environ["GOOGLE_PROJECT"]
     region = os.environ["GOOGLE_REGION"]
-    stack_name = os.environ["BIGTESTY_STACK_NAME"]
-
-    datasets_hash = get_datasets_hash(5)
+    stack_name = f'{datasets_hash}-{os.environ["BIGTESTY_STACK_NAME"]}'
 
     scenarios = get_scenarios(root_test_folder)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if os.path.isfile(path):
 
 setup(
     name="bigtesty",
-    version="0.1.1",
+    version="0.1.0",
     entry_points='''
         [console_scripts]
         bigtesty=bigtesty.cli.main:run
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         "pulumi-gcp==7.24.0",
         "google-cloud-bigquery==3.23.1",
+        "google-cloud-storage==2.17.0",
         "typer[all]==0.12.3",
         "pytest==8.2.1",
         "deepdiff==7.0.1",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if os.path.isfile(path):
 
 setup(
     name="bigtesty",
-    version="0.1.0",
+    version="0.1.1",
     entry_points='''
         [console_scripts]
         bigtesty=bigtesty.cli.main:run


### PR DESCRIPTION
Isolate the state with a unique name datasethash-bigtesty. With this unique name each execution is not linked with the previous. Previously all the states had the name bigtesty, and if we executed a test while keeping the infra and then executed a test with the native destroy mode, the previous created infra were also deleted. To prevent this kind of issue, we isolate the state with a unique name.

After destroying the ephemeral infra, delete the empty state files. Pulumi proposes this feature, in the CLI but not in the automation API. We developed this logic with the BigQuery Python client and when this feature will be available in the Pulumi automation, we will use it.